### PR TITLE
Avoid using i18n environment variable LANG

### DIFF
--- a/.common.mk
+++ b/.common.mk
@@ -9,7 +9,7 @@ SPEC_YAML := $(ROOT)/build/yaml-spec-1.2.yaml
 SPEC_PATCH := $(ROOT)/build/yaml-spec-1.2.patch
 GENERATOR := $(ROOT)/build/bin/generate-yaml-grammar
 GENERATOR_LIB := $(ROOT)/build/lib/generate-yaml-grammar.coffee
-GENERATOR_LANG_LIB := $(ROOT)/build/lib/generate-yaml-grammar-$(LANG).coffee
+GENERATOR_LANG_LIB := $(ROOT)/build/lib/generate-yaml-grammar-$(PARSER_LANG).coffee
 NODE_MODULES := $(ROOT)/node_modules
 
 PATH := $(NODE_MODULES)/.bin:$(PATH)
@@ -41,7 +41,7 @@ clean::
 $(GRAMMAR): $(SPEC_PATCHED_YAML) $(GENERATOR) $(GENERATOR_LIB) $(GENERATOR_LANG_LIB)
 	$(GENERATOR) \
 	    --from=$< \
-	    --to=$(LANG) \
+	    --to=$(PARSER_LANG) \
 	    --rule=l-yaml-stream \
 	> $@
 

--- a/coffeescript/Makefile
+++ b/coffeescript/Makefile
@@ -1,5 +1,5 @@
 ROOT := $(shell cd ..; pwd)
-LANG := coffeescript
+PARSER_LANG := coffeescript
 BIN := coffee
 GRAMMAR := lib/grammar.coffee
 

--- a/javascript/Makefile
+++ b/javascript/Makefile
@@ -1,5 +1,5 @@
 ROOT := $(shell cd ..; pwd)
-LANG := javascript
+PARSER_LANG := javascript
 BIN := node
 GRAMMAR :=
 

--- a/perl/Makefile
+++ b/perl/Makefile
@@ -1,5 +1,5 @@
 ROOT := $(shell cd ..; pwd)
-LANG := perl
+PARSER_LANG := perl
 BIN := perl
 GRAMMAR := lib/Grammar.pm
 


### PR DESCRIPTION
... to prevent warnings or even error(s) when running prove(1) because
locales 'coffeescript', 'javascript' and 'perl' are unknown: rename
variable LANG to PARSER_LANG.